### PR TITLE
Propagate prior to LocalScore

### DIFF
--- a/sumu/gadget.py
+++ b/sumu/gadget.py
@@ -1002,6 +1002,7 @@ class Gadget:
         self.l_score = LocalScore(
             data=self.data,
             score=self.p["score"],
+            prior=self.p["prior"],
             maxid=self.p["cons"]["max_id"],
         )
 
@@ -1049,6 +1050,7 @@ class Gadget:
             self.l_score = LocalScore(
                 data=self.data,
                 score=self.p["score"],
+                prior=self.p["prior"],
                 maxid=self.p["cons"]["d"],
             )
             self.c_c_score = CandidateComplementScore(


### PR DESCRIPTION
Currently `LocalScore` does not propagate the argument `prior`, which means that it is always using the default prior (`fair`). This PR fixes this, and correctly propagates the prior to `LocalScore`.